### PR TITLE
[fix] form-data로 받아왔을 시 array가 string이 되는 경우 수정

### DIFF
--- a/functions/db/memberDB.js
+++ b/functions/db/memberDB.js
@@ -84,7 +84,7 @@ const addMember = async (client, teamId, userIdList) => {
     return [];
   }
 
-  const valuesInsertQuery = userIdList.map((x) => `(${teamId}, ${x})`).join(', ');
+  const valuesInsertQuery = JSON.parse(userIdList).map((x) => `(${teamId}, ${x})`).join(', ');
   const { rows: resultRows } = await client.query(
     `
         INSERT INTO member


### PR DESCRIPTION
## 작업 내용

- [x] form-data로 body를 받아왔을 때 오류가 나는 경우 수정


## Related issue, PR :
#83



## 새로 알게 된 내용 및 Reference : 
json이 아닌 form-data로 받아오면 '[1, 2]' 이런 식으로 string이 되어 받게된다
JSON.parse(string)을 사용하면 쉽게 array로 바꿀 수 있다.


##  

