### PR TITLE
[fix] 마이페이지 픽하기 페이지네이션 분리

### DIFF
--- a/functions/api/routes/form/formAnswerPickFormListGET.js
+++ b/functions/api/routes/form/formAnswerPickFormListGET.js
@@ -1,0 +1,46 @@
+const functions = require('firebase-functions');
+const util = require('../../../lib/util');
+const statusCode = require('../../../constants/statusCode');
+const responseMessage = require('../../../constants/responseMessage');
+const db = require('../../../db/db');
+const { formDB } = require('../../../db');
+const slackAPI = require('../../../lib/slackAPI');
+
+module.exports = async (req, res) => {
+
+  const user = req.user
+  
+  if (!user) return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+  
+  let client;
+  
+  
+  
+  try {
+    client = await db.connect(req);
+
+    //^_^// 필터링을 위한 생성된 폼 정보 가져오기
+    const formData = await formDB.getCreatedFormListByUserId(client, user.id);
+
+    //^_^// 생성된 폼이 없을 경우 204 리턴
+    if (!formData) return res.status(statusCode.NO_CONTENT).send(util.success(statusCode.NO_CONTENT));
+
+    const resultData = {
+        form: formData
+    };
+    
+    res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_MY_FORM_LIST, resultData));
+    
+  } catch (error) {
+    functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);
+    console.log(error);
+    
+    const slackMessage = `[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl} ${req.user ? `uid:${req.user.id}` : 'req.user 없음'}
+ ${JSON.stringify(error)}`;
+    slackAPI.sendMessageToSlack(slackMessage, slackAPI.DEV_WEB_HOOK_ERROR_MONITORING);
+    res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.INTERNAL_SERVER_ERROR));
+    
+  } finally {
+    client.release();
+  }
+};

--- a/functions/api/routes/form/formAnswerPickGET.js
+++ b/functions/api/routes/form/formAnswerPickGET.js
@@ -31,7 +31,7 @@ module.exports = async (req, res) => {
 
     //^_^// 작성된 답변이 없는 경우 204 리턴
     if (answerData.length === 0) {
-      return res.status(statusCode.OK).send(util.success(statusCode.NO_CONTENT, NO_ANSWER_TO_PICK));
+      return res.status(statusCode.NO_CONTENT).send(util.success(statusCode.NO_CONTENT, NO_ANSWER_TO_PICK));
     }
 
 
@@ -56,8 +56,9 @@ module.exports = async (req, res) => {
     //^_^// key와 value값으로 구분 후 value값만 map함수로 빼내기
     const resultAnswerData = Object.entries(answerListPopId).map(([answerId, data]) => ({ ...data }));
 
+    //^_^// 나에게 작성된 답변들 리턴
     const resultData = {
-      answer:resultAnswerData
+      answer: resultAnswerData
     }
 
     res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_FILTERED_FORM_SUCCESS, resultData));

--- a/functions/api/routes/form/formAnswerPickGET.js
+++ b/functions/api/routes/form/formAnswerPickGET.js
@@ -22,24 +22,16 @@ module.exports = async (req, res) => {
   try {
     client = await db.connect(req);
 
-    //^_^// 가장 상단에 필터링을 위한 생성된 폼 정보 가져오기
-    const formData = await formDB.getCreatedFormListByUserId(client, userId);
-
-    //^_^// 생성된 폼이 없을 경우 204 리턴
-    if (!formData) return res.status(statusCode.NO_CONTENT).send(util.success(statusCode.NO_CONTENT));
-
     let answerData;
     if (!formId) { //^_^// 필터링할 폼아이디가 없을 경우 전부 가져오기
       answerData = await answerDB.getAllAnswerByUserId(client, userId, offset, limit);
     } else { //^_^// 필터링할 폼아이디가 있을 경우, 필터링한 답변만 가져오기
       answerData = await answerDB.getFilteredAnswerByFormId(client, userId, formId, offset, limit);
     }
-    //^_^// 작성된 답변이 없는 경우 폼 리스트만 리턴
+
+    //^_^// 작성된 답변이 없는 경우 204 리턴
     if (answerData.length === 0) {
-      const resultData = {
-        form: formData
-      }
-      return res.status(statusCode.OK).send(util.success(statusCode.OK, NO_ANSWER_TO_PICK, resultData));
+      return res.status(statusCode.OK).send(util.success(statusCode.NO_CONTENT, NO_ANSWER_TO_PICK));
     }
 
 
@@ -65,7 +57,6 @@ module.exports = async (req, res) => {
     const resultAnswerData = Object.entries(answerListPopId).map(([answerId, data]) => ({ ...data }));
 
     const resultData = {
-      form: formData,
       answer:resultAnswerData
     }
 

--- a/functions/api/routes/form/index.js
+++ b/functions/api/routes/form/index.js
@@ -16,6 +16,7 @@ router.get('/create/:formId', checkUser, require('./formCreateGET'));
 router.get('/detail/:formId', checkUser, require('./formDetailGET'));
 router.get('/detail/:formId/answer', checkUser, require('./formDetailAnswerGET'));
 router.put('/detail/answer/:answerId/pin', checkUser, require('./formDetailAnswerPinPUT'));
+router.get('/answer/pick/form', checkUser, require('./formAnswerPickFormListGET'));
 router.get('/answer/pick', checkUser, require('./formAnswerPickGET'));
 
 module.exports = router;

--- a/functions/api/routes/team/index.js
+++ b/functions/api/routes/team/index.js
@@ -36,5 +36,6 @@ router.delete('/member', checkUser, require('./teamMemberDELETE'));
 router.delete('/', checkUser, require('./teamDELETE'));
 
 router.get('/feedback/pick', checkUser, require('./teamFeedbackPickGET'));
+router.get('/feedback/pick/team', checkUser, require('./teamFeedbackPickTeamListGET'));
 
 module.exports = router;

--- a/functions/api/routes/team/teamFeedbackPickGET.js
+++ b/functions/api/routes/team/teamFeedbackPickGET.js
@@ -29,12 +29,9 @@ module.exports = async (req, res) => {
         feedbackData = await feedbackDB.getFilteredFeedbackByFormId(client, userId, teamId, offset, limit);
     };
 
-    //^_^// 나에게 작성된 피드백이 없는 경우
+    //^_^// 나에게 작성된 피드백이 없는 경우 204 리턴
     if (feedbackData.length === 0) {
-        const resultData = {
-            team: teamData
-        };
-        return res.status(statusCode.OK).send(util.success(statusCode.OK, NO_FEEDBACK_TO_PICK, resultData));
+      return res.status(statusCode.NO_CONTENT).send(util.success(statusCode.NO_CONTENT, NO_FEEDBACK_TO_PICK));
     };
 
     //^_^// 북마크한 피드백 리스트에서 아이디값 가져오기
@@ -58,7 +55,7 @@ module.exports = async (req, res) => {
     //^_^// key와 value값으로 구분 후 value값만 map함수로 빼내기
     const resultFeedbackData = Object.entries(feedbackListPopId).map(([feedbackId, data]) => ({ ...data }));
 
-    //^_^// 팀과 북마크한 피드백 리스트가 모두 있는 경우 return 데이터
+    //^_^// 피드백 리스트 return
     const resultData = {
       feedback: resultFeedbackData
     };

--- a/functions/api/routes/team/teamFeedbackPickGET.js
+++ b/functions/api/routes/team/teamFeedbackPickGET.js
@@ -22,12 +22,6 @@ module.exports = async (req, res) => {
   try {
     client = await db.connect(req);
 
-    //^_^// 가장 상단에 내가 속해있는 팀 가져오기
-    const teamData = await teamDB.getTeamListByUserId(client, userId);
-
-    //^_^// 속한 팀이 없을 경우 204 리턴
-    if (!teamData) return res.status(statusCode.NO_CONTENT).send(util.success(statusCode.NO_CONTENT));
- 
     let feedbackData;
     if(!teamId) { //^_^// 필터링할 팀아이디가 없는경우 전부 조회
         feedbackData = await feedbackDB.getAllFeedbackByUserId(client, userId, offset, limit);
@@ -66,8 +60,7 @@ module.exports = async (req, res) => {
 
     //^_^// 팀과 북마크한 피드백 리스트가 모두 있는 경우 return 데이터
     const resultData = {
-      team: teamData,
-      feedback: resultFeedbackData,
+      feedback: resultFeedbackData
     };
 
 

--- a/functions/api/routes/team/teamFeedbackPickTeamListGET.js
+++ b/functions/api/routes/team/teamFeedbackPickTeamListGET.js
@@ -1,0 +1,44 @@
+const functions = require('firebase-functions');
+const util = require('../../../lib/util');
+const statusCode = require('../../../constants/statusCode');
+const responseMessage = require('../../../constants/responseMessage');
+const db = require('../../../db/db');
+const { teamDB } = require('../../../db');
+const slackAPI = require('../../../lib/slackAPI');
+
+module.exports = async (req, res) => {
+
+  const user = req.user;
+  
+  if (!user) return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+  
+  let client;
+  
+  try {
+    client = await db.connect(req);
+
+    //^_^// 내가 속해있는 팀 가져오기
+    const teamData = await teamDB.getTeamListByUserId(client, user.id);
+
+    //^_^// 속한 팀이 없을 경우 204 리턴
+    if (!teamData) return res.status(statusCode.NO_CONTENT).send(util.success(statusCode.NO_CONTENT));
+        
+    const resultData = {
+        team: teamData
+    };
+    
+    res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_MY_TEAM_LIST, resultData));
+    
+  } catch (error) {
+    functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);
+    console.log(error);
+    
+    const slackMessage = `[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl} ${req.user ? `uid:${req.user.id}` : 'req.user 없음'}
+ ${JSON.stringify(error)}`;
+    slackAPI.sendMessageToSlack(slackMessage, slackAPI.DEV_WEB_HOOK_ERROR_MONITORING);
+    res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.INTERNAL_SERVER_ERROR));
+    
+  } finally {
+    client.release();
+  }
+};

--- a/functions/constants/responseMessage.js
+++ b/functions/constants/responseMessage.js
@@ -42,6 +42,7 @@ module.exports = {
   NO_TEAM: '존재하지 않는 팀입니다',
   UPDATE_TEAM: '팀 정보 수정 성공',
   DELETE_TEAM_SUCCESS: '팀 삭제 성공',
+  READ_MY_TEAM_LIST: '유저가 속해있는 팀 리스트 조회 성공',
 
   // 팀원 정보
   READ_MEMBER: '팀원 정보 조회 성공',

--- a/functions/constants/responseMessage.js
+++ b/functions/constants/responseMessage.js
@@ -100,7 +100,7 @@ module.exports = {
   READ_FORM_ANSWER_DETAIL_SUCCESS: '폼 디테일 답변 조회 성공 ',
   ANSWER_IS_PINNED_TOGGLE_SUCCESS: '답변 핀 토글 성공',
   NO_FORM_ISSUE: '팀 폼 답변 없음',
-  READ_MY_FORM_LIST: '유저가 생성한 폼 라스트 조회 성공',
+  READ_MY_FORM_LIST: '유저가 생성한 폼 리스트 조회 성공',
   READ_FILTERED_FORM_SUCCESS: '필터링된 폼 조회 성공',
   NO_ANSWER_TO_PICK: '내가 픽할 답변이 없습니다',
   NO_MORE_ANSWER: '더 이상 답변이 없습니다.',

--- a/functions/constants/responseMessage.js
+++ b/functions/constants/responseMessage.js
@@ -100,6 +100,7 @@ module.exports = {
   READ_FORM_ANSWER_DETAIL_SUCCESS: '폼 디테일 답변 조회 성공 ',
   ANSWER_IS_PINNED_TOGGLE_SUCCESS: '답변 핀 토글 성공',
   NO_FORM_ISSUE: '팀 폼 답변 없음',
+  READ_MY_FORM_LIST: '유저가 생성한 폼 라스트 조회 성공',
   READ_FILTERED_FORM_SUCCESS: '필터링된 폼 조회 성공',
   NO_ANSWER_TO_PICK: '내가 픽할 답변이 없습니다',
   NO_MORE_ANSWER: '더 이상 답변이 없습니다.',


### PR DESCRIPTION

## 작업 내용

- [x] 너가소개서 답변 픽하기 페이지네이션 분리
- [x] 팀원소개서 피드백 픽하기 페이지네이션 분리



## Related issue, PR :
#174 


## 새로 알게 된 내용 및 Reference : 
페이지네이션을 위해 리퀘스트를 요청할 때마다 필터링을 위한 폼/팀 리스트까지 다시 가져오는 것을 방지하기 위해
api를 분리하여 페이지네이션에서는 답변/피드백만 가져오도록 수정했습니다.


##  

