### PR TITLE
[feature] 삭제 시 하위 테이블 삭제 처리

### DIFF
--- a/functions/api/routes/team/teamDELETE.js
+++ b/functions/api/routes/team/teamDELETE.js
@@ -4,7 +4,8 @@ const statusCode = require('../../../constants/statusCode');
 const responseMessage = require('../../../constants/responseMessage');
 const db = require('../../../db/db');
 const slackAPI = require('../../../lib/slackAPI');
-const { teamDB } = require('../../../db');
+const { teamDB, memberDB, feedbackDB, linkFeedbacKeywordDB, keywordDB, issueDB } = require('../../../db');
+const arrayHandler = require('../../../lib/arrayHandler');
 
 module.exports = async (req, res) => {
   const { id: userId } = req.user;
@@ -17,13 +18,43 @@ module.exports = async (req, res) => {
   try {
     client = await db.connect(req);
 
+    //^_^// 팀 삭제 권한 여부 검사
     const teamHost = await teamDB.getIsHost(client, userId, teamId);
-    if (teamHost.isHost) {
-      const team = await teamDB.deleteTeam(client, teamId);
-      res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.DELETE_TEAM_SUCCESS, { team }));
-    } else {
+    if (!teamHost.isHost) {
       res.status(statusCode.FORBIDDEN).send(util.success(statusCode.FORBIDDEN, responseMessage.NO_AUTH_MEMBER));
     }
+
+    //^_^// 해당 팀에 포함된 이슈 조회 및 아이디 추출
+    const teamIssueList = await issueDB.getIssueIdRecentListByTeamId(client, teamId);
+    const teamIssueIdList = arrayHandler.extractValues(teamIssueList, 'id');
+
+    //^_^// 해당 이슈에 포함된 피드백 아이디 추출
+    const userIssueFeedbackList = await feedbackDB.getAllFeedbackByIssueIdList(client, teamIssueIdList);
+    const feedbackIdList = arrayHandler.extractValues(userIssueFeedbackList, 'id');
+
+    if (feedbackIdList.length > 0) {
+      //^_^// 해당 피드백에 포함된 키워드들 추출
+      const linkFeedbackKeywords = await linkFeedbacKeywordDB.getKeywordsWithFeedbackIdList(client, feedbackIdList);
+
+      //^_^// 삭제한 feedback에 담긴 키워드 삭제
+      const keywordIdsBeforeUpdate = arrayHandler.extractValues(linkFeedbackKeywords, 'id');
+      const deleteLinkFeedbackKeyword = await linkFeedbacKeywordDB.deleteLinkFeedbackListKeyword(client, feedbackIdList, keywordIdsBeforeUpdate);
+
+      //^_^// 삭제한 keyword count-- 업데이트
+      const deleteKeywords = await keywordDB.keywordCountDelete(client, keywordIdsBeforeUpdate);
+
+      //^_^// 쓴 피드백 삭제
+      const deletedFeedbackList = await feedbackDB.deleteFeedbackList(client, feedbackIdList);
+    }
+
+    //^_^// 해당 팀에 포함된 이슈 삭제
+    if (teamIssueIdList.length > 0) {
+      const deletedIssueList = await issueDB.deleteIssueList(client, teamIssueIdList);
+    }
+
+    //^_^// 팀 삭제
+    const team = await teamDB.deleteTeam(client, teamId);
+    res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.DELETE_TEAM_SUCCESS, { team }));
   } catch (error) {
     functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);
     console.log(error);

--- a/functions/api/routes/team/teamDELETE.js
+++ b/functions/api/routes/team/teamDELETE.js
@@ -52,6 +52,9 @@ module.exports = async (req, res) => {
       const deletedIssueList = await issueDB.deleteIssueList(client, teamIssueIdList);
     }
 
+    //^_^// 해당 팀에 포함된 멤버들 전부 삭제
+    const deletedMemberList = await memberDB.deleteAllMemberByTeamId(client, teamId);
+
     //^_^// 팀 삭제
     const team = await teamDB.deleteTeam(client, teamId);
     res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.DELETE_TEAM_SUCCESS, { team }));

--- a/functions/api/routes/team/teamHostPUT.js
+++ b/functions/api/routes/team/teamHostPUT.js
@@ -4,7 +4,8 @@ const statusCode = require('../../../constants/statusCode');
 const responseMessage = require('../../../constants/responseMessage');
 const db = require('../../../db/db');
 const slackAPI = require('../../../lib/slackAPI');
-const { memberDB } = require('../../../db');
+const { memberDB, feedbackDB, linkFeedbacKeywordDB, keywordDB, issueDB } = require('../../../db');
+const arrayHandler = require('../../../lib/arrayHandler');
 
 module.exports = async (req, res) => {
   const { id: userId } = req.user;
@@ -24,6 +25,41 @@ module.exports = async (req, res) => {
     }
     if (!isMember) {
       return res.status(statusCode.FORBIDDEN).send(util.success(statusCode.FORBIDDEN, responseMessage.NO_MEMBER));
+    }
+
+    //^_^// 해당 멤버가 쓴 이슈 조회 및 아이디 추출
+    const userIssueList = await issueDB.getAllIssueIdListByUserIdAndTeamId(client, userId, teamId);
+    const userIssueIdList = arrayHandler.extractValues(userIssueList, 'id');
+
+    //^_^// 해당 이슈에 포함되는 피드백 아이디 추출
+    const userIssueFeedbackList = await feedbackDB.getAllFeedbackByIssueIdList(client, userIssueIdList);
+    const userIssueFeedbackIdList = arrayHandler.extractValues(userIssueFeedbackList, 'id');
+
+    //^_^// 해당 팀 멤버가 포함된 또는 쓴 피드백 조회 및 아이디 추출
+    const userFeedbackList = await feedbackDB.getAllFeedbackByUserIdAndTeamId(client, userId, teamId);
+    const userFeedbackIdList = arrayHandler.extractValues(userFeedbackList, 'feedbackId');
+
+    //^_^// 위의 이슈에 포함된 피드백 아이디 + 해당 멤버가 포함되거나 쓴 피드백 아이디
+    const feedbackIdList = [...userIssueFeedbackIdList, ...userFeedbackIdList];
+
+    if (feedbackIdList.length > 0) {
+      //^_^// 해당 피드백에 포함된 키워드들 추출
+      const linkFeedbackKeywords = await linkFeedbacKeywordDB.getKeywordsWithFeedbackIdList(client, feedbackIdList);
+
+      //^_^// 삭제한 feedback에 담긴 키워드 삭제
+      const keywordIdsBeforeUpdate = arrayHandler.extractValues(linkFeedbackKeywords, 'id');
+      const deleteLinkFeedbackKeyword = await linkFeedbacKeywordDB.deleteLinkFeedbackListKeyword(client, feedbackIdList, keywordIdsBeforeUpdate);
+
+      //^_^// 삭제한 keyword count-- 업데이트
+      const deleteKeywords = await keywordDB.keywordCountDelete(client, keywordIdsBeforeUpdate);
+
+      //^_^// 쓴 피드백 삭제
+      const deletedFeedbackList = await feedbackDB.deleteFeedbackList(client, feedbackIdList);
+    }
+
+    //^_^// 해당 멤버가 쓴 이슈 삭제
+    if (userIssueIdList.length > 0) {
+      const deletedIssueList = await issueDB.deleteIssueList(client, userIssueIdList);
     }
 
     const oldHost = await memberDB.updateOldHost(client, userId, teamId);

--- a/functions/api/routes/team/teamMemberDELETE.js
+++ b/functions/api/routes/team/teamMemberDELETE.js
@@ -4,8 +4,10 @@ const statusCode = require('../../../constants/statusCode');
 const responseMessage = require('../../../constants/responseMessage');
 const db = require('../../../db/db');
 const slackAPI = require('../../../lib/slackAPI');
-const { memberDB } = require('../../../db');
+const { memberDB, feedbackDB, linkFeedbacKeywordDB, keywordDB, issueDB } = require('../../../db');
 const { isFunction } = require('lodash');
+const arrayHandler = require('../../../lib/arrayHandler');
+const { user } = require('firebase-functions/v1/auth');
 
 module.exports = async (req, res) => {
   const { id: userId } = req.user;
@@ -18,12 +20,50 @@ module.exports = async (req, res) => {
   try {
     client = await db.connect(req);
 
+    //^_^// 해당 멤버 get
     const isMember = await memberDB.checkMemberTeam(client, userId, teamId);
     if (!isMember) {
       return res.status(statusCode.FORBIDDEN).send(util.success(statusCode.FORBIDDEN, responseMessage.NO_MEMBER));
     }
 
+    //^_^// 해당 멤버가 쓴 이슈 조회 및 아이디 추출
+    const userIssueList = await issueDB.getAllIssueIdListByUserIdAndTeamId(client, userId, teamId);
+    const userIssueIdList = arrayHandler.extractValues(userIssueList, 'id');
+
+    //^_^// 해당 이슈에 포함되는 피드백 아이디 추출
+    const userIssueFeedbackList = await feedbackDB.getAllFeedbackByIssueIdList(client, userIssueIdList);
+    const userIssueFeedbackIdList = arrayHandler.extractValues(userIssueFeedbackList, 'id');
+
+    //^_^// 해당 팀 멤버가 포함된 또는 쓴 피드백 조회 및 아이디 추출
+    const userFeedbackList = await feedbackDB.getAllFeedbackByUserIdAndTeamId(client, userId, teamId);
+    const userFeedbackIdList = arrayHandler.extractValues(userFeedbackList, 'feedbackId');
+
+    //^_^// 위의 이슈에 포함된 피드백 아이디 + 해당 멤버가 포함되거나 쓴 피드백 아이디
+    const feedbackIdList = [...userIssueFeedbackIdList, ...userFeedbackIdList];
+
+    if (feedbackIdList.length > 0) {
+      //^_^// 해당 피드백에 포함된 키워드들 추출
+      const linkFeedbackKeywords = await linkFeedbacKeywordDB.getKeywordsWithFeedbackIdList(client, feedbackIdList);
+
+      //^_^// 삭제한 feedback에 담긴 키워드 삭제
+      const keywordIdsBeforeUpdate = arrayHandler.extractValues(linkFeedbackKeywords, 'id');
+      const deleteLinkFeedbackKeyword = await linkFeedbacKeywordDB.deleteLinkFeedbackListKeyword(client, feedbackIdList, keywordIdsBeforeUpdate);
+
+      //^_^// 삭제한 keyword count-- 업데이트
+      const deleteKeywords = await keywordDB.keywordCountDelete(client, keywordIdsBeforeUpdate);
+
+      //^_^// 쓴 피드백 삭제
+      const deletedFeedbackList = await feedbackDB.deleteFeedbackList(client, feedbackIdList);
+    }
+
+    //^_^// 해당 멤버가 쓴 이슈 삭제
+    if (userIssueIdList.length > 0) {
+      const deletedIssueList = await issueDB.deleteIssueList(client, userIssueIdList);
+    }
+
+    //^_^// 해당 멤버 삭제
     const member = await memberDB.deleteMember(client, userId, teamId);
+
     res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.DELETE_MEMBER_SUCCESS, { member }));
   } catch (error) {
     functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);

--- a/functions/db/feedbackDB.js
+++ b/functions/db/feedbackDB.js
@@ -141,6 +141,53 @@ const deleteFeedback = async (client, feedbackId) => {
   return convertSnakeToCamel.keysToCamel(rows[0]);
 };
 
+const deleteFeedbackList = async (client, feedbackIdList) => {
+  const { rows } = await client.query(/*sql*/ `
+    UPDATE feedback
+  SET is_deleted = true, updated_at = now()
+  WHERE id in (${feedbackIdList.join()})
+  AND is_deleted = false
+  RETURNING *`);
+  return convertSnakeToCamel.keysToCamel(rows);
+};
+
+const getAllFeedbackByUserIdAndTeamId = async (client, userId, teamId) => {
+  const { rows } = await client.query(
+    `
+    SELECT f.id as feedback_id, t.id as team_id, 
+      f.user_id as writer_user_id, u2.name as writer_user_name, 
+      f.tagged_user_id as user_id, u.name as user_name, 
+      f.created_at, f.content, f.is_pinned
+    FROM feedback f
+    JOIN "user" u ON u.id = f.tagged_user_id
+    JOIN "user" u2 ON u2.id = f.user_id
+    JOIN issue i ON f.issue_id = i.id
+    JOIN team t ON i.team_id = t.id
+    WHERE t.id = $2
+      AND (f.tagged_user_id = $1
+          OR f.user_id = $1
+          )
+      AND f.is_deleted = false
+      AND u.is_deleted = false
+      AND u2.is_deleted = false
+      AND i.is_deleted = false
+      AND t.is_deleted = falsE
+    `,
+    [userId, teamId],
+  );
+  return convertSnakeToCamel.keysToCamel(rows);
+};
+
+const getAllFeedbackByIssueIdList = async (client, issueIdList) => {
+  const { rows } = await client.query(/*sql*/ `
+    SELECT f.id
+    FROM feedback f
+    WHERE f.issue_id in (${issueIdList.join()})
+      AND f.is_deleted = false
+    `);
+  return convertSnakeToCamel.keysToCamel(rows);
+};
+
 module.exports = {
   addFeedback,
   getFeedbacks,
@@ -151,4 +198,7 @@ module.exports = {
   deleteFeedback,
   getFeedbackById,
   editFeedback,
+  deleteFeedbackList,
+  getAllFeedbackByUserIdAndTeamId,
+  getAllFeedbackByIssueIdList,
 };

--- a/functions/db/issueDB.js
+++ b/functions/db/issueDB.js
@@ -246,6 +246,32 @@ const getTeamMemberByIssueId = async (client, issueId) => {
   return convertSnakeToCamel.keysToCamel(rows);
 };
 
+const getAllIssueIdListByUserIdAndTeamId = async (client, userId, teamId) => {
+  const { rows } = await client.query(
+    `
+    SELECT id
+    FROM issue
+    WHERE user_id = $1
+    AND team_id = $2
+    AND is_deleted=false
+    `,
+    [userId, teamId],
+  );
+  return convertSnakeToCamel.keysToCamel(rows);
+};
+
+const deleteIssueList = async (client, issueIdList) => {
+  const { rows } = await client.query(
+    `
+    UPDATE issue
+    SET is_deleted = true
+    WHERE id IN (${issueIdList.join()})
+    RETURNING *
+    `,
+  );
+  return convertSnakeToCamel.keysToCamel(rows);
+};
+
 module.exports = {
   getFeedbackIdRecentListByUserId,
   getIssueIdRecentListByTeamId,
@@ -263,4 +289,6 @@ module.exports = {
   deleteIssue,
   getTeamIdByIssueId,
   getTeamMemberByIssueId,
+  getAllIssueIdListByUserIdAndTeamId,
+  deleteIssueList,
 };

--- a/functions/db/keywordDB.js
+++ b/functions/db/keywordDB.js
@@ -284,7 +284,7 @@ const updateLinkFeedbackKeywordsForSet = async (client, id, idList) => {
         AND is_deleted = false
         RETURNING *
         `);
-      return convertSnakeToCamel.keysToCamel(rows);
+  return convertSnakeToCamel.keysToCamel(rows);
 };
 const getUserKeywordListCount = async (client, userId) => {
   const { rows } = await client.query(`

--- a/functions/db/linkFeedbacKeywordDB.js
+++ b/functions/db/linkFeedbacKeywordDB.js
@@ -64,4 +64,21 @@ const getTopKeywordListOnFeedback = async (client, userId) => {
   return convertSnakeToCamel.keysToCamel(rows);
 };
 
-module.exports = { addLinkFeedbackKeyword, deleteLinkFeedbackKeyword, getKeywordsWithFeedbackIdList, getTopKeywordListOnFeedback };
+const deleteLinkFeedbackListKeyword = async (client, feedbackIdList, keywordIds) => {
+  let rows = { rows: null };
+  if (keywordIds.length > 0) {
+    rows = await client.query(/*sql*/ `
+            UPDATE link_feedback_keyword
+            SET is_deleted = true
+            WHERE feedback_id IN (${feedbackIdList.join()})
+            AND is_deleted = false
+            AND link_feedback_keyword.keyword_id IN (${keywordIds.join()})
+            RETURNING *
+
+            `);
+  }
+
+  return convertSnakeToCamel.keysToCamel(rows);
+};
+
+module.exports = { addLinkFeedbackKeyword, deleteLinkFeedbackKeyword, getKeywordsWithFeedbackIdList, getTopKeywordListOnFeedback, deleteLinkFeedbackListKeyword };

--- a/functions/db/memberDB.js
+++ b/functions/db/memberDB.js
@@ -273,6 +273,22 @@ const checkUserIsHost = async (client, userId) => {
   return convertSnakeToCamel.keysToCamel(rows);
 };
 
+const deleteAllMemberByTeamId = async (client, teamId) => {
+  const { rows } = await client.query(
+    `
+    UPDATE member
+    SET is_deleted = true,
+    updated_at = NOW()
+    WHERE team_id = $1
+    RETURNING *
+    `,
+
+    [teamId],
+  );
+
+  return convertSnakeToCamel.keysToCamel(rows);
+};
+
 module.exports = {
   getAllTeamByUserId,
   getAllTeamMemberByTeamId,
@@ -290,4 +306,5 @@ module.exports = {
   getMemberByTeamId,
   checkDuplicateMember,
   checkUserIsHost,
+  deleteAllMemberByTeamId,
 };


### PR DESCRIPTION

## 작업 내용

*팀 멤버 삭제시 (팀 나가기, 팀장 위임하고 나가기)*
- [x] 해당 팀 멤버가 포함된 피드백, 쓴 피드백 삭제
- [x] 해당 피드백에 포함된 키워드들도 삭제(link 테이블에서만 삭제 + count --해줘야함)
- [x] 해당 팀 멤버가 쓴 이슈 삭제

*팀 삭제시*
- [x] 해당 팀에 연관된 이슈 전부 삭제
- [x] 이슈에 연관된 피드백 전부 삭제
- [x] 해당 피드백에 포함된 키워드들도 삭제(link 테이블에서만 삭제 + count --해줘야함)
- [x] 멤버 테이블에서 해당 팀에 속한 멤버 삭제


## Related issue, PR :
#207


## 새로 알게 된 내용 및 Reference : 



##  

